### PR TITLE
Fix provisioning issue

### DIFF
--- a/roles/galaxy-docker/tasks/provision/installgenomes.yml
+++ b/roles/galaxy-docker/tasks/provision/installgenomes.yml
@@ -29,28 +29,6 @@
     var: dbkeys
     verbosity: 1
 
-# This should be fed from the command line.
-- name: delete api key from files
-  lineinfile:
-    destfile: "{{item.path}}"
-    regexp: "api_key:.*"
-    state: absent
-  with_items:
-    - "{{dbkeys.files}}"
-  become: no
-  delegate_to: 127.0.0.1
-
-# It should be this instance. So no room for interpretation in the the yamls.
-- name: delete galaxy_instance from files
-  lineinfile:
-    destfile: "{{item.path}}"
-    regexp: "galaxy_instance:.*"
-    state: absent
-  with_items:
-    - "{{dbkeys.files}}"
-  become: no
-  delegate_to: 127.0.0.1
-
 - name: Move dbkeys to galaxy server
   copy:
     dest: "{{galaxy_docker_dbkeys_dir}}/{{item.path | basename}}"
@@ -60,12 +38,29 @@
   with_items:
     - "{{dbkeys.files}}"
 
+# This should be fed from the command line.
+- name: delete api key from files
+  lineinfile:
+    destfile: "{{galaxy_docker_dbkeys_dir}}/{{item.path | basename}}"
+    regexp: "api_key:.*"
+    state: absent
+  with_items:
+    - "{{dbkeys.files}}"
+
+# It should be this instance. So no room for interpretation in the the yamls.
+- name: delete galaxy_instance from files
+  lineinfile:
+    destfile: "{{galaxy_docker_dbkeys_dir}}/{{item.path | basename}}"
+    regexp: "galaxy_instance:.*"
+    state: absent
+  with_items:
+    - "{{dbkeys.files}}"
+
 - name: Use ephemeris run-data-managers to run data managers
   command: "{{galaxy_docker_docker_user_virtualenv}}/bin/run-data-managers -g localhost:{{galaxy_docker_provision_port}} -a {{galaxy_admin_api_key}} --config {{galaxy_docker_dbkeys_dir}}/{{item.path | basename}} -v"
   with_items: "{{dbkeys.files}}"
   ignore_errors: yes # If databases fail galaxy is still restarted so the ones that did not fail are available
   register: result
-  notify: restart galaxy in container
 
 - name: Debug ephemeris output
   debug:

--- a/roles/galaxy-docker/tasks/provision/installtools.yml
+++ b/roles/galaxy-docker/tasks/provision/installtools.yml
@@ -29,32 +29,28 @@
     var: tools
     verbosity: 1
 
-- name: delete api key from files
-  lineinfile:
-    destfile: "{{item.path}}"
-    regexp: "api_key:.*"
-    state: absent
-  with_items:
-    - "{{tools.files}}"
-  become: no
-  delegate_to: 127.0.0.1
-
-- name: delete galaxy_instance from files
-  lineinfile:
-    destfile: "{{item.path}}"
-    regexp: "galaxy_instance:.*"
-    state: absent
-  with_items:
-    - "{{tools.files}}"
-  become: no
-  delegate_to: 127.0.0.1
-
 - name: Move tools to galaxy server
   copy:
     dest: "{{galaxy_docker_tool_dir}}/{{item.path | basename}}"
     src: "{{item.path}}"
     force: yes
     mode: 0600
+  with_items:
+    - "{{tools.files}}"
+
+- name: delete api key from files
+  lineinfile:
+    destfile: "{{galaxy_docker_tool_dir}}/{{item.path | basename}}"
+    regexp: "api_key:.*"
+    state: absent
+  with_items:
+    - "{{tools.files}}"
+
+- name: delete galaxy_instance from files
+  lineinfile:
+    destfile: "{{galaxy_docker_tool_dir}}/{{item.path | basename}}"
+    regexp: "galaxy_instance:.*"
+    state: absent
   with_items:
     - "{{tools.files}}"
 

--- a/roles/galaxy-docker/templates/docker_environment_provision.j2
+++ b/roles/galaxy-docker/templates/docker_environment_provision.j2
@@ -18,7 +18,8 @@
 #####
 #
 GALAXY_CONFIG_ADMIN_USERS={{galaxy_docker_provision_user}}
-GALAXY_CONFIG_MASTER_API_KEY={{galaxy_docker_provision_key}}
+#Master API KEY should not be the same as admin api key of provision user.
+GALAXY_CONFIG_MASTER_API_KEY=NOT{{galaxy_docker_provision_key}}
 GALAXY_CONFIG_BRAND={{galaxy_brand}}
 #
 #####


### PR DESCRIPTION
The provision container did not work because the master api key was the same as the provision api key. Connections with that api key defaulted to the master (non-existent) user, which created an error running the data managers.
The master api key is now not the same as the provision key. 